### PR TITLE
Fix orders filling at the top-of-book price instead of the submitted order price.

### DIFF
--- a/engine/orderbook_test.go
+++ b/engine/orderbook_test.go
@@ -419,7 +419,6 @@ func TestOrderFillAtTopPriceSell(t *testing.T) {
     for i := 0; i < 2; i++ {
         select {
         case fill := <-fillCh:
-            t.Logf("Received fill: %+v", fill)
             if fill.OrderID == "BUY-1" {
                 if !fill.ExecutedQty.Equal(decimal.NewFromFloat(1)) {
                     t.Errorf("Expected 'BUY-1' executed quantity 1, got %s", fill.ExecutedQty.String())
@@ -487,7 +486,6 @@ func TestOrderFillAtTopPriceBuy(t *testing.T) {
     for i := 0; i < 2; i++ {
         select {
         case fill := <-fillCh:
-            t.Logf("Received fill: %+v", fill)
             if fill.OrderID == "BUY-1" {
                 if !fill.ExecutedQty.Equal(decimal.NewFromFloat(1)) {
                     t.Errorf("Expected 'BUY-1' executed quantity 1, got %s", fill.ExecutedQty.String())

--- a/engine/orderbook_test.go
+++ b/engine/orderbook_test.go
@@ -1,387 +1,524 @@
 package engine
 
 import (
-	"testing"
-	"time"
+    "testing"
+    "time"
 
-	"github.com/shopspring/decimal"
+    "github.com/shopspring/decimal"
 )
 
 // TestNewOrderBook tests the creation of a new order book
 func TestNewOrderBook(t *testing.T) {
-	pair := "BTC-USDT"
-	ob := NewOrderBook(pair)
+    pair := "BTC-USDT"
+    ob := NewOrderBook(pair)
 
-	if ob.Pair != pair {
-		t.Errorf("Expected pair %s, got %s", pair, ob.Pair)
-	}
+    if ob.Pair != pair {
+        t.Errorf("Expected pair %s, got %s", pair, ob.Pair)
+    }
 
-	if ob.BestBid() != 0 {
-		t.Errorf("Expected empty order book to have 0 best bid, got %f", ob.BestBid())
-	}
+    if ob.BestBid() != 0 {
+        t.Errorf("Expected empty order book to have 0 best bid, got %f", ob.BestBid())
+    }
 
-	if ob.BestAsk() != 0 {
-		t.Errorf("Expected empty order book to have 0 best ask, got %f", ob.BestAsk())
-	}
+    if ob.BestAsk() != 0 {
+        t.Errorf("Expected empty order book to have 0 best ask, got %f", ob.BestAsk())
+    }
 }
 
 // TestOrderBookBestPrices tests the BestBid and BestAsk methods
 func TestOrderBookBestPrices(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add a buy order
-	buyOrder := Order{
-		ID:    "buy1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
+    // Add a buy order
+    buyOrder := Order{
+        ID:    "buy1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
 
-	// Add a sell order
-	sellOrder := Order{
-		ID:    "sell1",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(105.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
+    // Add a sell order
+    sellOrder := Order{
+        ID:    "sell1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(105.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
 
-	// Check best prices
-	if ob.BestBid() != 100.0 {
-		t.Errorf("Expected best bid 100.0, got %f", ob.BestBid())
-	}
+    // Check best prices
+    if ob.BestBid() != 100.0 {
+        t.Errorf("Expected best bid 100.0, got %f", ob.BestBid())
+    }
 
-	if ob.BestAsk() != 105.0 {
-		t.Errorf("Expected best ask 105.0, got %f", ob.BestAsk())
-	}
+    if ob.BestAsk() != 105.0 {
+        t.Errorf("Expected best ask 105.0, got %f", ob.BestAsk())
+    }
 }
 
 // TestOrderBookMatching tests the order matching functionality
 func TestOrderBookMatching(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add a sell order first
-	sellOrder := Order{
-		ID:    "sell1",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
+    // Add a sell order first
+    sellOrder := Order{
+        ID:    "sell1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
 
-	// Drain the fill channel
-	<-fillCh
+    // Drain the fill channel
+    <-fillCh
 
-	// Add a matching buy order
-	buyOrder := Order{
-		ID:    "buy1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
+    // Add a matching buy order
+    buyOrder := Order{
+        ID:    "buy1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
 
-	// Check that a trade was generated
-	select {
-	case trade := <-tradeCh:
-		if trade.BuyOrderID != "buy1" {
-			t.Errorf("Expected buy order ID 'buy1', got %s", trade.BuyOrderID)
-		}
-		if trade.SellOrderID != "sell1" {
-			t.Errorf("Expected sell order ID 'sell1', got %s", trade.SellOrderID)
-		}
-		if !trade.Price.Equal(decimal.NewFromFloat(100.0)) {
-			t.Errorf("Expected trade price 100.0, got %s", trade.Price.String())
-		}
-		if !trade.Qty.Equal(decimal.NewFromFloat(1.0)) {
-			t.Errorf("Expected trade quantity 1.0, got %s", trade.Qty.String())
-		}
-	default:
-		t.Error("Expected a trade to be generated")
-	}
+    // Check that a trade was generated
+    select {
+    case trade := <-tradeCh:
+        if trade.BuyOrderID != "buy1" {
+            t.Errorf("Expected buy order ID 'buy1', got %s", trade.BuyOrderID)
+        }
+        if trade.SellOrderID != "sell1" {
+            t.Errorf("Expected sell order ID 'sell1', got %s", trade.SellOrderID)
+        }
+        if !trade.Price.Equal(decimal.NewFromFloat(100.0)) {
+            t.Errorf("Expected trade price 100.0, got %s", trade.Price.String())
+        }
+        if !trade.Qty.Equal(decimal.NewFromFloat(1.0)) {
+            t.Errorf("Expected trade quantity 1.0, got %s", trade.Qty.String())
+        }
+    default:
+        t.Error("Expected a trade to be generated")
+    }
 
-	// Check fill events - should have 2 fills (one for each order)
-	fillCount := 0
-	for len(fillCh) > 0 {
-		<-fillCh
-		fillCount++
-	}
-	if fillCount != 2 {
-		t.Errorf("Expected 2 fill events, got %d", fillCount)
-	}
+    // Check fill events - should have 2 fills (one for each order)
+    fillCount := 0
+    for len(fillCh) > 0 {
+        <-fillCh
+        fillCount++
+    }
+    if fillCount != 2 {
+        t.Errorf("Expected 2 fill events, got %d", fillCount)
+    }
 }
 
 // TestPartialFill tests partial order filling
 func TestPartialFill(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add a large sell order
-	sellOrder := Order{
-		ID:    "sell1",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(5.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
+    // Add a large sell order
+    sellOrder := Order{
+        ID:    "sell1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(5.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
 
-	// Drain the fill channel
-	<-fillCh
+    // Drain the fill channel
+    <-fillCh
 
-	// Add a smaller buy order
-	buyOrder := Order{
-		ID:    "buy1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(2.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
+    // Add a smaller buy order
+    buyOrder := Order{
+        ID:    "buy1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(2.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
 
-	// Check trade
-	select {
-	case trade := <-tradeCh:
-		if !trade.Qty.Equal(decimal.NewFromFloat(2.0)) {
-			t.Errorf("Expected trade quantity 2.0, got %s", trade.Qty.String())
-		}
-	default:
-		t.Error("Expected a trade to be generated")
-	}
+    // Check trade
+    select {
+    case trade := <-tradeCh:
+        if !trade.Qty.Equal(decimal.NewFromFloat(2.0)) {
+            t.Errorf("Expected trade quantity 2.0, got %s", trade.Qty.String())
+        }
+    default:
+        t.Error("Expected a trade to be generated")
+    }
 
-	// Check that there's still an ask in the book (partially filled sell order)
-	if ob.BestAsk() != 100.0 {
-		t.Errorf("Expected remaining ask at 100.0, got %f", ob.BestAsk())
-	}
+    // Check that there's still an ask in the book (partially filled sell order)
+    if ob.BestAsk() != 100.0 {
+        t.Errorf("Expected remaining ask at 100.0, got %f", ob.BestAsk())
+    }
 }
 
 // TestMultiplePriceLevels tests orders at different price levels
 func TestMultiplePriceLevels(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add buy orders at different prices
-	buyOrder1 := Order{
-		ID:    "buy1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder1, tradeCh, fillCh, buyOrder1.Qty)
+    // Add buy orders at different prices
+    buyOrder1 := Order{
+        ID:    "buy1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder1, tradeCh, fillCh, buyOrder1.Qty)
 
-	buyOrder2 := Order{
-		ID:    "buy2",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(99.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder2, tradeCh, fillCh, buyOrder2.Qty)
+    buyOrder2 := Order{
+        ID:    "buy2",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(99.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder2, tradeCh, fillCh, buyOrder2.Qty)
 
-	// Best bid should be the higher price
-	if ob.BestBid() != 100.0 {
-		t.Errorf("Expected best bid 100.0, got %f", ob.BestBid())
-	}
+    // Best bid should be the higher price
+    if ob.BestBid() != 100.0 {
+        t.Errorf("Expected best bid 100.0, got %f", ob.BestBid())
+    }
 
-	// Add sell orders at different prices
-	sellOrder1 := Order{
-		ID:    "sell1",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(105.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder1, tradeCh, fillCh, sellOrder1.Qty)
+    // Add sell orders at different prices
+    sellOrder1 := Order{
+        ID:    "sell1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(105.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder1, tradeCh, fillCh, sellOrder1.Qty)
 
-	sellOrder2 := Order{
-		ID:    "sell2",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(104.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder2, tradeCh, fillCh, sellOrder2.Qty)
+    sellOrder2 := Order{
+        ID:    "sell2",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(104.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder2, tradeCh, fillCh, sellOrder2.Qty)
 
-	// Best ask should be the lower price
-	if ob.BestAsk() != 104.0 {
-		t.Errorf("Expected best ask 104.0, got %f", ob.BestAsk())
-	}
+    // Best ask should be the lower price
+    if ob.BestAsk() != 104.0 {
+        t.Errorf("Expected best ask 104.0, got %f", ob.BestAsk())
+    }
 }
 
 // TestGetBidDepth tests the bid depth functionality
 func TestGetBidDepth(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add multiple buy orders at same price
-	buyOrder1 := Order{
-		ID:    "buy1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder1, tradeCh, fillCh, buyOrder1.Qty)
+    // Add multiple buy orders at same price
+    buyOrder1 := Order{
+        ID:    "buy1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder1, tradeCh, fillCh, buyOrder1.Qty)
 
-	buyOrder2 := Order{
-		ID:    "buy2",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(2.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder2, tradeCh, fillCh, buyOrder2.Qty)
+    buyOrder2 := Order{
+        ID:    "buy2",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(2.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder2, tradeCh, fillCh, buyOrder2.Qty)
 
-	// Add buy order at different price
-	buyOrder3 := Order{
-		ID:    "buy3",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(99.0),
-		Qty:   decimal.NewFromFloat(1.5),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(buyOrder3, tradeCh, fillCh, buyOrder3.Qty)
+    // Add buy order at different price
+    buyOrder3 := Order{
+        ID:    "buy3",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(99.0),
+        Qty:   decimal.NewFromFloat(1.5),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(buyOrder3, tradeCh, fillCh, buyOrder3.Qty)
 
-	// Test depth
-	depth := ob.GetBidDepth(2)
-	if len(depth) != 2 {
-		t.Errorf("Expected 2 depth levels, got %d", len(depth))
-	}
+    // Test depth
+    depth := ob.GetBidDepth(2)
+    if len(depth) != 2 {
+        t.Errorf("Expected 2 depth levels, got %d", len(depth))
+    }
 
-	// First level should be at 100.0 with quantity 3.0
-	if !depth[0].Price.Equal(decimal.NewFromFloat(100.0)) {
-		t.Errorf("Expected first level price 100.0, got %s", depth[0].Price.String())
-	}
-	if !depth[0].Quantity.Equal(decimal.NewFromFloat(3.0)) {
-		t.Errorf("Expected first level quantity 3.0, got %s", depth[0].Quantity.String())
-	}
-	if depth[0].TradeCount != 2 {
-		t.Errorf("Expected first level trade count 2, got %d", depth[0].TradeCount)
-	}
+    // First level should be at 100.0 with quantity 3.0
+    if !depth[0].Price.Equal(decimal.NewFromFloat(100.0)) {
+        t.Errorf("Expected first level price 100.0, got %s", depth[0].Price.String())
+    }
+    if !depth[0].Quantity.Equal(decimal.NewFromFloat(3.0)) {
+        t.Errorf("Expected first level quantity 3.0, got %s", depth[0].Quantity.String())
+    }
+    if depth[0].TradeCount != 2 {
+        t.Errorf("Expected first level trade count 2, got %d", depth[0].TradeCount)
+    }
 }
 
 // TestGetAskDepth tests the ask depth functionality
 func TestGetAskDepth(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add multiple sell orders
-	sellOrder1 := Order{
-		ID:    "sell1",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(105.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder1, tradeCh, fillCh, sellOrder1.Qty)
+    // Add multiple sell orders
+    sellOrder1 := Order{
+        ID:    "sell1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(105.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder1, tradeCh, fillCh, sellOrder1.Qty)
 
-	sellOrder2 := Order{
-		ID:    "sell2",
-		Side:  Sell,
-		Price: decimal.NewFromFloat(104.0),
-		Qty:   decimal.NewFromFloat(2.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(sellOrder2, tradeCh, fillCh, sellOrder2.Qty)
+    sellOrder2 := Order{
+        ID:    "sell2",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(104.0),
+        Qty:   decimal.NewFromFloat(2.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(sellOrder2, tradeCh, fillCh, sellOrder2.Qty)
 
-	// Test depth
-	depth := ob.GetAskDepth(2)
-	if len(depth) != 2 {
-		t.Errorf("Expected 2 depth levels, got %d", len(depth))
-	}
+    // Test depth
+    depth := ob.GetAskDepth(2)
+    if len(depth) != 2 {
+        t.Errorf("Expected 2 depth levels, got %d", len(depth))
+    }
 
-	// First level should be the lowest price (104.0)
-	if !depth[0].Price.Equal(decimal.NewFromFloat(104.0)) {
-		t.Errorf("Expected first level price 104.0, got %s", depth[0].Price.String())
-	}
+    // First level should be the lowest price (104.0)
+    if !depth[0].Price.Equal(decimal.NewFromFloat(104.0)) {
+        t.Errorf("Expected first level price 104.0, got %s", depth[0].Price.String())
+    }
 }
 
 // TestEmptyDepth tests depth methods with empty order book
 func TestEmptyDepth(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
+    ob := NewOrderBook("BTC-USDT")
 
-	bidDepth := ob.GetBidDepth(5)
-	if len(bidDepth) != 0 {
-		t.Errorf("Expected empty bid depth, got %d levels", len(bidDepth))
-	}
+    bidDepth := ob.GetBidDepth(5)
+    if len(bidDepth) != 0 {
+        t.Errorf("Expected empty bid depth, got %d levels", len(bidDepth))
+    }
 
-	askDepth := ob.GetAskDepth(5)
-	if len(askDepth) != 0 {
-		t.Errorf("Expected empty ask depth, got %d levels", len(askDepth))
-	}
+    askDepth := ob.GetAskDepth(5)
+    if len(askDepth) != 0 {
+        t.Errorf("Expected empty ask depth, got %d levels", len(askDepth))
+    }
 }
 
 // TestInvalidDepth tests depth methods with invalid parameters
 func TestInvalidDepth(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add an order
-	order := Order{
-		ID:    "test1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(order, tradeCh, fillCh, order.Qty)
+    // Add an order
+    order := Order{
+        ID:    "test1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(order, tradeCh, fillCh, order.Qty)
 
-	// Test with invalid depth parameters
-	bidDepth := ob.GetBidDepth(0)
-	if len(bidDepth) != 0 {
-		t.Errorf("Expected empty result for depth 0, got %d levels", len(bidDepth))
-	}
+    // Test with invalid depth parameters
+    bidDepth := ob.GetBidDepth(0)
+    if len(bidDepth) != 0 {
+        t.Errorf("Expected empty result for depth 0, got %d levels", len(bidDepth))
+    }
 
-	bidDepth = ob.GetBidDepth(-1)
-	if len(bidDepth) != 0 {
-		t.Errorf("Expected empty result for negative depth, got %d levels", len(bidDepth))
-	}
+    bidDepth = ob.GetBidDepth(-1)
+    if len(bidDepth) != 0 {
+        t.Errorf("Expected empty result for negative depth, got %d levels", len(bidDepth))
+    }
 }
 
 // TestOrderFillEvents tests that proper fill events are generated
 func TestOrderFillEvents(t *testing.T) {
-	ob := NewOrderBook("BTC-USDT")
-	tradeCh := make(chan Trade, 10)
-	fillCh := make(chan OrderFill, 10)
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
 
-	// Add a new order that doesn't match
-	order := Order{
-		ID:    "test1",
-		Side:  Buy,
-		Price: decimal.NewFromFloat(100.0),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	}
-	ob.Match(order, tradeCh, fillCh, order.Qty)
+    // Add a new order that doesn't match
+    order := Order{
+        ID:    "test1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(100.0),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    }
+    ob.Match(order, tradeCh, fillCh, order.Qty)
 
-	// Should receive one fill event with status "NEW"
-	select {
-	case fill := <-fillCh:
-		if fill.Status != New {
-			t.Errorf("Expected status NEW, got %s", fill.Status)
-		}
-		if fill.OrderID != "test1" {
-			t.Errorf("Expected order ID 'test1', got %s", fill.OrderID)
-		}
-		if !fill.ExecutedQty.IsZero() {
-			t.Errorf("Expected executed quantity 0, got %s", fill.ExecutedQty.String())
-		}
-	default:
-		t.Error("Expected a fill event to be generated")
-	}
+    // Should receive one fill event with status "NEW"
+    select {
+    case fill := <-fillCh:
+        if fill.Status != New {
+            t.Errorf("Expected status NEW, got %s", fill.Status)
+        }
+        if fill.OrderID != "test1" {
+            t.Errorf("Expected order ID 'test1', got %s", fill.OrderID)
+        }
+        if !fill.ExecutedQty.IsZero() {
+            t.Errorf("Expected executed quantity 0, got %s", fill.ExecutedQty.String())
+        }
+    default:
+        t.Error("Expected a fill event to be generated")
+    }
+}
+
+// TestOrderFillAtTopPriceSell tests that SELL orders are filled at the top BUY price, not SELL order price
+func TestOrderFillAtTopPriceSell(t *testing.T) {
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
+
+    // Add a buy order at the top price
+    buyOrder := Order{
+        ID:    "BUY-1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(2),
+        Qty:   decimal.NewFromFloat(1),
+        Time:  time.Now().Unix(),
+    }
+
+    ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
+
+    // Skip the NEW fill event for BUY-1
+    <-fillCh
+
+    sellOrder := Order{
+        ID:    "SELL-1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(1),
+        Qty:   decimal.NewFromFloat(1),
+        Time:  time.Now().Unix(),
+    }
+
+    ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
+
+    for i := 0; i < 2; i++ {
+        select {
+        case fill := <-fillCh:
+            t.Logf("Received fill: %+v", fill)
+            if fill.OrderID == "BUY-1" {
+                if !fill.ExecutedQty.Equal(decimal.NewFromFloat(1)) {
+                    t.Errorf("Expected 'BUY-1' executed quantity 1, got %s", fill.ExecutedQty.String())
+                }
+                if !fill.Price.Equal(decimal.NewFromFloat(2)) {
+                    t.Errorf("Expected 'BUY-1' fill price 2, got %s", fill.Price.String())
+                }
+
+                if fill.Status != Filled {
+                    t.Errorf("Expected 'BUY-1' status Filled, got %s", fill.Status)
+                }
+            }
+
+            if fill.OrderID == "SELL-1" {
+                if !fill.ExecutedQty.Equal(decimal.NewFromFloat(1)) {
+                    t.Errorf("Expected 'SELL-1' executed quantity 1, got %s", fill.ExecutedQty.String())
+                }
+                if !fill.Price.Equal(decimal.NewFromFloat(2)) {
+                    t.Errorf("Expected 'SELL-1' fill price 2, got %s", fill.Price.String())
+                }
+
+                if fill.Status != Filled {
+                    t.Errorf("Expected 'SELL-1' status Filled, got %s", fill.Status)
+                }
+            }
+
+            if fill.Status != Filled {
+                t.Errorf("Expected status Filled, got %s", fill.Status)
+            }
+        default:
+            time.Sleep(100 * time.Millisecond)
+        }
+    }
+}
+
+// TestOrderFillAtTopPriceBuy tests that BUY orders are filled at the BOTTOM SELL price, not BUY order price
+func TestOrderFillAtTopPriceBuy(t *testing.T) {
+    ob := NewOrderBook("BTC-USDT")
+    tradeCh := make(chan Trade, 10)
+    fillCh := make(chan OrderFill, 10)
+
+    sellOrder := Order{
+        ID:    "SELL-1",
+        Side:  Sell,
+        Price: decimal.NewFromFloat(1),
+        Qty:   decimal.NewFromFloat(1),
+        Time:  time.Now().Unix(),
+    }
+
+    ob.Match(sellOrder, tradeCh, fillCh, sellOrder.Qty)
+
+    // Skip the NEW fill event for SELL-1
+    <-fillCh
+
+    buyOrder := Order{
+        ID:    "BUY-1",
+        Side:  Buy,
+        Price: decimal.NewFromFloat(2),
+        Qty:   decimal.NewFromFloat(1),
+        Time:  time.Now().Unix(),
+    }
+
+    ob.Match(buyOrder, tradeCh, fillCh, buyOrder.Qty)
+
+    for i := 0; i < 2; i++ {
+        select {
+        case fill := <-fillCh:
+            t.Logf("Received fill: %+v", fill)
+            if fill.OrderID == "BUY-1" {
+                if !fill.ExecutedQty.Equal(decimal.NewFromFloat(1)) {
+                    t.Errorf("Expected 'BUY-1' executed quantity 1, got %s", fill.ExecutedQty.String())
+                }
+                if !fill.Price.Equal(decimal.NewFromFloat(1)) {
+                    t.Errorf("Expected 'BUY-1' fill price 2, got %s", fill.Price.String())
+                }
+
+                if fill.Status != Filled {
+                    t.Errorf("Expected 'BUY-1' status Filled, got %s", fill.Status)
+                }
+            }
+
+            if fill.OrderID == "SELL-1" {
+                if !fill.ExecutedQty.Equal(decimal.NewFromFloat(1)) {
+                    t.Errorf("Expected 'SELL-1' executed quantity 1, got %s", fill.ExecutedQty.String())
+                }
+                if !fill.Price.Equal(decimal.NewFromFloat(1)) {
+                    t.Errorf("Expected 'SELL-1' fill price 2, got %s", fill.Price.String())
+                }
+
+                if fill.Status != Filled {
+                    t.Errorf("Expected 'SELL-1' status Filled, got %s", fill.Status)
+                }
+            }
+
+            if fill.Status != Filled {
+                t.Errorf("Expected status Filled, got %s", fill.Status)
+            }
+        default:
+            time.Sleep(100 * time.Millisecond)
+        }
+    }
 }

--- a/engine/orderbook_test.go
+++ b/engine/orderbook_test.go
@@ -491,7 +491,7 @@ func TestOrderFillAtTopPriceBuy(t *testing.T) {
                     t.Errorf("Expected 'BUY-1' executed quantity 1, got %s", fill.ExecutedQty.String())
                 }
                 if !fill.Price.Equal(decimal.NewFromFloat(1)) {
-                    t.Errorf("Expected 'BUY-1' fill price 2, got %s", fill.Price.String())
+                    t.Errorf("Expected 'BUY-1' fill price 1, got %s", fill.Price.String())
                 }
 
                 if fill.Status != Filled {
@@ -504,7 +504,7 @@ func TestOrderFillAtTopPriceBuy(t *testing.T) {
                     t.Errorf("Expected 'SELL-1' executed quantity 1, got %s", fill.ExecutedQty.String())
                 }
                 if !fill.Price.Equal(decimal.NewFromFloat(1)) {
-                    t.Errorf("Expected 'SELL-1' fill price 2, got %s", fill.Price.String())
+                    t.Errorf("Expected 'SELL-1' fill price 1, got %s", fill.Price.String())
                 }
 
                 if fill.Status != Filled {

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,162 +1,182 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/mkhoshkam/orderbook/engine"
-
-	"github.com/shopspring/decimal"
+    "fmt"
+    "github.com/mkhoshkam/orderbook/engine"
+    "github.com/shopspring/decimal"
+    "time"
 )
 
 func main() {
-	e := engine.NewEngine()
+    e := engine.NewEngine()
 
-	e.StartPriceBroadcaster()
-	e.StartDepthStreamer(5)
+    e.StartPriceBroadcaster()
+    e.StartDepthStreamer(5)
 
-	go func() {
-		for trade := range e.TradeStream {
-			fmt.Printf("[TRADE] %s %.4f @ %.2f\n",
-				trade.Pair,
-				trade.Qty.InexactFloat64(),
-				trade.Price.InexactFloat64())
-		}
-	}()
+    // go func() {
+    //     for trade := range e.TradeStream {
+    //         fmt.Printf("[TRADE] %s %.4f @ %.2f\n",
+    //             trade.Pair,
+    //             trade.Qty.InexactFloat64(),
+    //             trade.Price.InexactFloat64())
+    //     }
+    // }()
 
-	go func() {
-		for price := range e.PriceUpdates {
-			fmt.Printf("[PRICE] %s BID: %.2f / ASK: %.2f / AVG: %.2f\n",
-				price.Pair,
-				price.BestBid.InexactFloat64(),
-				price.BestAsk.InexactFloat64(),
-				price.AvgPrice.InexactFloat64())
-		}
-	}()
+    go func() {
+        for price := range e.PriceUpdates {
+            fmt.Printf("[PRICE] %s BID: %.4f / ASK: %.4f / AVG: %.4f\n",
+                price.Pair,
+                price.BestBid.InexactFloat64(),
+                price.BestAsk.InexactFloat64(),
+                price.AvgPrice.InexactFloat64())
+        }
+    }()
 
-	// Listen to order fill events
-	go func() {
-		for fill := range e.FillStream {
-			fmt.Printf("[FILL] Order %s (%s %s) - Status: %s | Executed: %.4f | Remaining: %.4f | Fill Price: %.2f\n",
-				fill.OrderID,
-				fill.Side,
-				fill.Pair,
-				fill.Status,
-				fill.ExecutedQty.InexactFloat64(),
-				fill.RemainingQty.InexactFloat64(),
-				fill.FillPrice.InexactFloat64())
-		}
-	}()
+    // Listen to order fill events
+    go func() {
+        for fill := range e.FillStream {
+            fmt.Printf("[FILL] Order %s (%s %s) - Status: %s | Executed: %.4f | Remaining: %.4f | Price: %.4f | Fill Price: %.4f\n",
+                fill.OrderID,
+                fill.Side,
+                fill.Pair,
+                fill.Status,
+                fill.ExecutedQty.InexactFloat64(),
+                fill.RemainingQty.InexactFloat64(),
+                fill.Price.InexactFloat64(),
+                fill.FillPrice.InexactFloat64())
+        }
+    }()
 
-	go func() {
-		for depth := range e.DepthUpdates {
-			fmt.Printf("\n[DEPTH] %s (Trades: %d)\n", depth.Pair, depth.TradeCount)
+    // go func() {
+    //     for depth := range e.DepthUpdates {
+    //         fmt.Printf("\n[DEPTH] %s (Trades: %d)\n", depth.Pair, depth.TradeCount)
+    //
+    //         fmt.Println("BIDS")
+    //         for i, bid := range depth.Bids {
+    //             fmt.Printf("  %d. %.4f | %.4f (%d orders)\n",
+    //                 i+1,
+    //                 bid.Price.InexactFloat64(),
+    //                 bid.Quantity.InexactFloat64(),
+    //                 bid.TradeCount)
+    //         }
+    //         fmt.Println("---")
+    //
+    //         for i, ask := range depth.Asks {
+    //             fmt.Printf("  %d. %.4f | %.4f (%d orders)\n",
+    //                 i+1,
+    //                 ask.Price.InexactFloat64(),
+    //                 ask.Quantity.InexactFloat64(),
+    //                 ask.TradeCount)
+    //         }
+    //         fmt.Println("ASKS")
+    //         time.Sleep(2 * time.Second) // Sleep to avoid flooding the console
+    //     }
+    // }()
 
-			fmt.Println("BIDS:")
-			for i, bid := range depth.Bids {
-				fmt.Printf("  %d. %.2f | %.4f (%d orders)\n",
-					i+1,
-					bid.Price.InexactFloat64(),
-					bid.Quantity.InexactFloat64(),
-					bid.TradeCount)
-			}
+    fmt.Println("Adding orders...")
 
-			fmt.Println("ASKS:")
-			for i, ask := range depth.Asks {
-				fmt.Printf("  %d. %.2f | %.4f (%d orders)\n",
-					i+1,
-					ask.Price.InexactFloat64(),
-					ask.Quantity.InexactFloat64(),
-					ask.TradeCount)
-			}
-			fmt.Println("---")
-		}
-	}()
+    // for i := 0; i < 10; i++ {
+    //     time.Sleep(200 * time.Millisecond)
+    //     randomNumber := rand.Intn(999) // Random number between 0 and 999
+    //     randomPair := randomNumber % 1 // 0 for BTC/USDT, 1 for ETH/USDT
+    //
+    //     var pair string
+    //     switch randomPair {
+    //     case 0:
+    //         pair = "BTC/USDT"
+    //     case 1:
+    //         pair = "ETH/USDT"
+    //     case 2:
+    //         pair = "LTC/USDT"
+    //     case 3:
+    //         pair = "XRP/USDT"
+    //     }
+    //
+    //     // random orders
+    //     side := engine.Buy
+    //     if !(rand.Intn(2) == 0) {
+    //         side = engine.Sell
+    //     }
+    //
+    //     order := engine.Order{
+    //         ID:    fmt.Sprintf("ORDER-%d", i),
+    //         Side:  side,
+    //         Price: decimal.NewFromFloat(rand.Float64() * 100000),
+    //         Qty:   decimal.NewFromFloat(rand.Float64() * 10),
+    //         Time:  time.Now().Unix(),
+    //     }
+    //     e.AddOrder(pair, order)
+    //
+    //     // fmt.Printf("Added order %s: %s %.4f @ %.2f\n", order.ID, order.Side, order.Qty.InexactFloat64(), order.Price.InexactFloat64())
+    //
+    // }
 
-	fmt.Println("Adding orders...")
+    e.AddOrder("BTC/USDT", engine.Order{
+        ID:    "BUY-2",
+        Side:  engine.Buy,
+        Price: decimal.NewFromFloat(2),
+        Qty:   decimal.NewFromFloat(1),
+        Time:  time.Now().Unix(),
+    })
 
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "BUY-1",
-		Side:  engine.Buy,
-		Price: decimal.NewFromFloat(30000),
-		Qty:   decimal.NewFromFloat(0.5),
-		Time:  time.Now().Unix(),
-	})
+    e.AddOrder("BTC/USDT", engine.Order{
+        ID:    "SELL-1",
+        Side:  engine.Sell,
+        Price: decimal.NewFromFloat(1),
+        Qty:   decimal.NewFromFloat(1),
+        Time:  time.Now().Unix(),
+    })
+    //
+    // e.AddOrder("BTC/USDT", engine.Order{
+    // 	ID:    "SELL-2",
+    // 	Side:  engine.Sell,
+    // 	Price: decimal.NewFromFloat(30200),
+    // 	Qty:   decimal.NewFromFloat(0.6),
+    // 	Time:  time.Now().Unix(),
+    // })
+    //
+    // time.Sleep(2 * time.Second)
+    // fmt.Println("\n=== Adding market buy order (should trigger fills) ===")
+    //
+    // // This order will match with SELL-1 (0.4) and partially with SELL-2
+    // e.AddOrder("BTC/USDT", engine.Order{
+    // 	ID:    "BUY-MARKET",
+    // 	Side:  engine.Buy,
+    // 	Price: decimal.NewFromFloat(30300), // High price to trigger market execution
+    // 	Qty:   decimal.NewFromFloat(0.8),   // More than SELL-1, will trigger partial fill of SELL-2
+    // 	Time:  time.Now().Unix(),
+    // })
+    //
+    // time.Sleep(2 * time.Second)
+    // fmt.Println("\n=== Adding large sell order (should partially fill) ===")
+    //
+    // // This will match with remaining buy orders but won't fill completely
+    // e.AddOrder("BTC/USDT", engine.Order{
+    // 	ID:    "SELL-LARGE",
+    // 	Side:  engine.Sell,
+    // 	Price: decimal.NewFromFloat(29000), // Low price to trigger market execution
+    // 	Qty:   decimal.NewFromFloat(2.0),   // Large quantity, will be partially filled
+    // 	Time:  time.Now().Unix(),
+    // })
+    //
+    // time.Sleep(3 * time.Second)
+    // fmt.Println("\n=== Adding ETH orders ===")
+    //
+    // e.AddOrder("ETH/USDT", engine.Order{
+    // 	ID:    "ETH-BUY-1",
+    // 	Side:  engine.Buy,
+    // 	Price: decimal.NewFromFloat(2000),
+    // 	Qty:   decimal.NewFromFloat(1.0),
+    // 	Time:  time.Now().Unix(),
+    // })
+    //
+    // e.AddOrder("ETH/USDT", engine.Order{
+    // 	ID:    "ETH-SELL-1",
+    // 	Side:  engine.Sell,
+    // 	Price: decimal.NewFromFloat(2010),
+    // 	Qty:   decimal.NewFromFloat(0.8),
+    // 	Time:  time.Now().Unix(),
+    // })
 
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "BUY-2",
-		Side:  engine.Buy,
-		Price: decimal.NewFromFloat(29900),
-		Qty:   decimal.NewFromFloat(0.3),
-		Time:  time.Now().Unix(),
-	})
-
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "BUY-3",
-		Side:  engine.Buy,
-		Price: decimal.NewFromFloat(29900),
-		Qty:   decimal.NewFromFloat(0.2),
-		Time:  time.Now().Unix(),
-	})
-
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "SELL-1",
-		Side:  engine.Sell,
-		Price: decimal.NewFromFloat(30100),
-		Qty:   decimal.NewFromFloat(0.4),
-		Time:  time.Now().Unix(),
-	})
-
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "SELL-2",
-		Side:  engine.Sell,
-		Price: decimal.NewFromFloat(30200),
-		Qty:   decimal.NewFromFloat(0.6),
-		Time:  time.Now().Unix(),
-	})
-
-	time.Sleep(2 * time.Second)
-	fmt.Println("\n=== Adding market buy order (should trigger fills) ===")
-
-	// This order will match with SELL-1 (0.4) and partially with SELL-2
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "BUY-MARKET",
-		Side:  engine.Buy,
-		Price: decimal.NewFromFloat(30300), // High price to trigger market execution
-		Qty:   decimal.NewFromFloat(0.8),   // More than SELL-1, will trigger partial fill of SELL-2
-		Time:  time.Now().Unix(),
-	})
-
-	time.Sleep(2 * time.Second)
-	fmt.Println("\n=== Adding large sell order (should partially fill) ===")
-
-	// This will match with remaining buy orders but won't fill completely
-	e.AddOrder("BTC/USDT", engine.Order{
-		ID:    "SELL-LARGE",
-		Side:  engine.Sell,
-		Price: decimal.NewFromFloat(29000), // Low price to trigger market execution
-		Qty:   decimal.NewFromFloat(2.0),   // Large quantity, will be partially filled
-		Time:  time.Now().Unix(),
-	})
-
-	time.Sleep(3 * time.Second)
-	fmt.Println("\n=== Adding ETH orders ===")
-
-	e.AddOrder("ETH/USDT", engine.Order{
-		ID:    "ETH-BUY-1",
-		Side:  engine.Buy,
-		Price: decimal.NewFromFloat(2000),
-		Qty:   decimal.NewFromFloat(1.0),
-		Time:  time.Now().Unix(),
-	})
-
-	e.AddOrder("ETH/USDT", engine.Order{
-		ID:    "ETH-SELL-1",
-		Side:  engine.Sell,
-		Price: decimal.NewFromFloat(2010),
-		Qty:   decimal.NewFromFloat(0.8),
-		Time:  time.Now().Unix(),
-	})
-
-	select {}
+    select {}
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -13,14 +13,14 @@ func main() {
     e.StartPriceBroadcaster()
     e.StartDepthStreamer(5)
 
-    // go func() {
-    //     for trade := range e.TradeStream {
-    //         fmt.Printf("[TRADE] %s %.4f @ %.2f\n",
-    //             trade.Pair,
-    //             trade.Qty.InexactFloat64(),
-    //             trade.Price.InexactFloat64())
-    //     }
-    // }()
+    go func() {
+        for trade := range e.TradeStream {
+            fmt.Printf("[TRADE] %s %.4f @ %.2f\n",
+                trade.Pair,
+                trade.Qty.InexactFloat64(),
+                trade.Price.InexactFloat64())
+        }
+    }()
 
     go func() {
         for price := range e.PriceUpdates {
@@ -47,38 +47,40 @@ func main() {
         }
     }()
 
-    // go func() {
-    //     for depth := range e.DepthUpdates {
-    //         fmt.Printf("\n[DEPTH] %s (Trades: %d)\n", depth.Pair, depth.TradeCount)
-    //
-    //         fmt.Println("BIDS")
-    //         for i, bid := range depth.Bids {
-    //             fmt.Printf("  %d. %.4f | %.4f (%d orders)\n",
-    //                 i+1,
-    //                 bid.Price.InexactFloat64(),
-    //                 bid.Quantity.InexactFloat64(),
-    //                 bid.TradeCount)
-    //         }
-    //         fmt.Println("---")
-    //
-    //         for i, ask := range depth.Asks {
-    //             fmt.Printf("  %d. %.4f | %.4f (%d orders)\n",
-    //                 i+1,
-    //                 ask.Price.InexactFloat64(),
-    //                 ask.Quantity.InexactFloat64(),
-    //                 ask.TradeCount)
-    //         }
-    //         fmt.Println("ASKS")
-    //         time.Sleep(2 * time.Second) // Sleep to avoid flooding the console
-    //     }
-    // }()
+    go func() {
+        for depth := range e.DepthUpdates {
+            fmt.Printf("\n[DEPTH] %s (Trades: %d)\n", depth.Pair, depth.TradeCount)
+
+            fmt.Println("BIDS")
+            for i, bid := range depth.Bids {
+                fmt.Printf("  %d. %.4f | %.4f (%d orders)\n",
+                    i+1,
+                    bid.Price.InexactFloat64(),
+                    bid.Quantity.InexactFloat64(),
+                    bid.TradeCount)
+            }
+            fmt.Println("---")
+
+            for i, ask := range depth.Asks {
+                fmt.Printf("  %d. %.4f | %.4f (%d orders)\n",
+                    i+1,
+                    ask.Price.InexactFloat64(),
+                    ask.Quantity.InexactFloat64(),
+                    ask.TradeCount)
+            }
+            fmt.Println("ASKS")
+            time.Sleep(2 * time.Second) // Sleep to avoid flooding the console
+        }
+    }()
 
     fmt.Println("Adding orders...")
 
-    // for i := 0; i < 10; i++ {
+    // Bulk order generation for testing
+
+    // for i := 0; i < 10000; i++ {
     //     time.Sleep(200 * time.Millisecond)
     //     randomNumber := rand.Intn(999) // Random number between 0 and 999
-    //     randomPair := randomNumber % 1 // 0 for BTC/USDT, 1 for ETH/USDT
+    //     randomPair := randomNumber % 4 // 0 for BTC/USDT, 1 for ETH/USDT
     //
     //     var pair string
     //     switch randomPair {
@@ -107,8 +109,6 @@ func main() {
     //     }
     //     e.AddOrder(pair, order)
     //
-    //     // fmt.Printf("Added order %s: %s %.4f @ %.2f\n", order.ID, order.Side, order.Qty.InexactFloat64(), order.Price.InexactFloat64())
-    //
     // }
 
     e.AddOrder("BTC/USDT", engine.Order{
@@ -126,57 +126,57 @@ func main() {
         Qty:   decimal.NewFromFloat(1),
         Time:  time.Now().Unix(),
     })
-    //
-    // e.AddOrder("BTC/USDT", engine.Order{
-    // 	ID:    "SELL-2",
-    // 	Side:  engine.Sell,
-    // 	Price: decimal.NewFromFloat(30200),
-    // 	Qty:   decimal.NewFromFloat(0.6),
-    // 	Time:  time.Now().Unix(),
-    // })
-    //
-    // time.Sleep(2 * time.Second)
-    // fmt.Println("\n=== Adding market buy order (should trigger fills) ===")
-    //
-    // // This order will match with SELL-1 (0.4) and partially with SELL-2
-    // e.AddOrder("BTC/USDT", engine.Order{
-    // 	ID:    "BUY-MARKET",
-    // 	Side:  engine.Buy,
-    // 	Price: decimal.NewFromFloat(30300), // High price to trigger market execution
-    // 	Qty:   decimal.NewFromFloat(0.8),   // More than SELL-1, will trigger partial fill of SELL-2
-    // 	Time:  time.Now().Unix(),
-    // })
-    //
-    // time.Sleep(2 * time.Second)
-    // fmt.Println("\n=== Adding large sell order (should partially fill) ===")
-    //
-    // // This will match with remaining buy orders but won't fill completely
-    // e.AddOrder("BTC/USDT", engine.Order{
-    // 	ID:    "SELL-LARGE",
-    // 	Side:  engine.Sell,
-    // 	Price: decimal.NewFromFloat(29000), // Low price to trigger market execution
-    // 	Qty:   decimal.NewFromFloat(2.0),   // Large quantity, will be partially filled
-    // 	Time:  time.Now().Unix(),
-    // })
-    //
-    // time.Sleep(3 * time.Second)
-    // fmt.Println("\n=== Adding ETH orders ===")
-    //
-    // e.AddOrder("ETH/USDT", engine.Order{
-    // 	ID:    "ETH-BUY-1",
-    // 	Side:  engine.Buy,
-    // 	Price: decimal.NewFromFloat(2000),
-    // 	Qty:   decimal.NewFromFloat(1.0),
-    // 	Time:  time.Now().Unix(),
-    // })
-    //
-    // e.AddOrder("ETH/USDT", engine.Order{
-    // 	ID:    "ETH-SELL-1",
-    // 	Side:  engine.Sell,
-    // 	Price: decimal.NewFromFloat(2010),
-    // 	Qty:   decimal.NewFromFloat(0.8),
-    // 	Time:  time.Now().Unix(),
-    // })
+
+    e.AddOrder("BTC/USDT", engine.Order{
+        ID:    "SELL-2",
+        Side:  engine.Sell,
+        Price: decimal.NewFromFloat(30200),
+        Qty:   decimal.NewFromFloat(0.6),
+        Time:  time.Now().Unix(),
+    })
+
+    time.Sleep(2 * time.Second)
+    fmt.Println("\n=== Adding market buy order (should trigger fills) ===")
+
+    // This order will match with SELL-1 (0.4) and partially with SELL-2
+    e.AddOrder("BTC/USDT", engine.Order{
+        ID:    "BUY-MARKET",
+        Side:  engine.Buy,
+        Price: decimal.NewFromFloat(30300), // High price to trigger market execution
+        Qty:   decimal.NewFromFloat(0.8),   // More than SELL-1, will trigger partial fill of SELL-2
+        Time:  time.Now().Unix(),
+    })
+
+    time.Sleep(2 * time.Second)
+    fmt.Println("\n=== Adding large sell order (should partially fill) ===")
+
+    // This will match with remaining buy orders but won't fill completely
+    e.AddOrder("BTC/USDT", engine.Order{
+        ID:    "SELL-LARGE",
+        Side:  engine.Sell,
+        Price: decimal.NewFromFloat(29000), // Low price to trigger market execution
+        Qty:   decimal.NewFromFloat(2.0),   // Large quantity, will be partially filled
+        Time:  time.Now().Unix(),
+    })
+
+    time.Sleep(3 * time.Second)
+    fmt.Println("\n=== Adding ETH orders ===")
+
+    e.AddOrder("ETH/USDT", engine.Order{
+        ID:    "ETH-BUY-1",
+        Side:  engine.Buy,
+        Price: decimal.NewFromFloat(2000),
+        Qty:   decimal.NewFromFloat(1.0),
+        Time:  time.Now().Unix(),
+    })
+
+    e.AddOrder("ETH/USDT", engine.Order{
+        ID:    "ETH-SELL-1",
+        Side:  engine.Sell,
+        Price: decimal.NewFromFloat(2010),
+        Qty:   decimal.NewFromFloat(0.8),
+        Time:  time.Now().Unix(),
+    })
 
     select {}
 }


### PR DESCRIPTION
Fixed case where if a buy order was submitted at price of 2 and a sell order was submitted at 1. 

The sell order would be filled at 1 and the buy order would be filled at 2. 

With this fix both the sell and buy orders are filled at the top-of-book price, eg 2 in this case.