### PR TITLE
Add benchmark tests for orderbook

### DIFF
--- a/engine/benchmark_orderbook_test.go
+++ b/engine/benchmark_orderbook_test.go
@@ -1,0 +1,71 @@
+package engine
+
+import (
+    "fmt"
+    "github.com/shopspring/decimal"
+    "log"
+    "math/rand/v2"
+    "testing"
+    "time"
+)
+
+var book = NewOrderBook("BTC-USDT")
+var fillCount = 0
+var tradeCount = 0
+var orders = make([]Order, 0, 2000000)
+
+func init() {
+    log.Println("Generating random order data for benchmark tests")
+    for i := 0; i < 2000000; i++ {
+        randomPrice := rand.Float64() * 150000.0
+        randomQty := rand.Float64() * 100.0
+
+        side := Buy
+        if rand.Int32()%2 == 0 {
+            side = Sell
+        }
+
+        order := Order{
+            ID:    fmt.Sprintf("O%d", i),
+            Side:  side,
+            Price: decimal.NewFromFloat(randomPrice),
+            Qty:   decimal.NewFromFloat(randomQty),
+            Time:  time.Now().Unix(),
+        }
+        orders = append(orders, order)
+    }
+
+}
+
+func BenchmarkWithRandomData(benchmark *testing.B) {
+    tradeCh := make(chan Trade, 100)
+    fillCh := make(chan OrderFill, 100)
+
+    go func() {
+        for trade := range tradeCh {
+            _ = trade
+            tradeCount++
+        }
+    }()
+    go func() {
+        for fill := range fillCh {
+            _ = fill
+            fillCount++
+        }
+    }()
+
+    // submit orders to the order book
+    for i := 0; i < benchmark.N; i++ {
+        book.Match(orders[i], tradeCh, fillCh, orders[i].Qty)
+    }
+
+    // Wait for all trades and fills to be processed
+    for len(tradeCh) > 0 || len(fillCh) > 0 {
+        time.Sleep(100 * time.Millisecond)
+    }
+
+    close(tradeCh)
+    close(fillCh)
+
+    fmt.Printf("Total trades processed: %d, Total orders filled: %d\n", tradeCount, fillCount)
+}


### PR DESCRIPTION
Title.

Example output:
```
2025/06/03 23:33:29 Generating random order data for benchmark tests
goos: windows
goarch: amd64
pkg: github.com/mkhoshkam/orderbook/engine
cpu: AMD Ryzen Threadripper 1920X 12-Core Processor 
BenchmarkWithRandomData
Total trades processed: 0, Total orders filled: 0
Total trades processed: 9, Total orders filled: 15
Total trades processed: 571, Total orders filled: 882
Total trades processed: 5145, Total orders filled: 7968
Total trades processed: 68580, Total orders filled: 106208
Total trades processed: 162784, Total orders filled: 252053
BenchmarkWithRandomData-24    	  120625	      9731 ns/op
PASS

Process finished with the exit code 0
```